### PR TITLE
Update condition to run build to prevent triggering an unnecessary builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,21 +11,18 @@
 
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
+# Note: Any changes to this workflow would be used only after merging into develop
 name: Build with unit tests
 
 on:
-  push:
-    branches: [ develop, release/** ]
-  pull_request:
-    branches: [ develop, release/** ]
-    types: [opened, synchronize, reopened, labeled]
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Trigger build
+      types:
+        - completed
 
 jobs:
   build:
-
-    if: contains(github.event.pull_request.labels.*.name, 'build') || github.event_name == 'workflow_dispatch'
     runs-on: k8s-runner-build
 
     steps:
@@ -47,3 +44,10 @@ jobs:
           path: |
             **/target/rat.txt
             **/target/surefire-reports/*
+      - name: Surefire Report
+        # Pinned 1.0.5 version
+        uses: ScaCap/action-surefire-report@ad808943e6bfbd2e6acba7c53fdb5c89534da533
+        if: always()
+        with:
+          # GITHUB_TOKEN
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,47 @@
+# Copyright © 2021 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# This workflow will trigger maven.yml only when needed.
+# This way we don't flood main workflow run list
+# Note that maven.yml from develop will be used even for PR builds
+# Also it will have access to the proper GITHUB_SECRET
+
+name: Trigger build
+
+on:
+  push:
+    branches: [ develop, release/** ]
+  pull_request:
+    branches: [ develop, release/** ]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    # We allow builds:
+    # 1) When triggered manually
+    # 2) When it's a merge into a branch
+    # 3) For PRs that are labeled as build and
+    #  - It's a code change
+    #  - A build label was just added
+    # A bit complex, but prevents builds when other labels are manipulated
+    if: >
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'push'
+      || (contains(github.event.pull_request.labels.*.name, 'build')
+         && (github.event.action != 'labeled' || github.event.label.name == 'build')
+         )
+
+    steps:
+      - name: Trigger build
+        run: echo Maven build will be triggered now


### PR DESCRIPTION
Previously adding unrelated labels would trigger the build. Now for "labeled" action we check label name.
Also in the if "push" is allowed, this way we test the result after PR is merged.